### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		}
 	},
 	"types": "dist/index.d.ts",
+	"main": "./entry/index.cjs",
 	"files": [
 		"/entry/",
 		"/dist/"


### PR DESCRIPTION
`package.json` lacks a `"main"` property. This prevents some tools such as bundlephobia from working, e.g. see https://bundlephobia.com/package/react-hydration-provider

I think this could fix it!